### PR TITLE
Add onFingerUpTimeout option to set a customizable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,27 @@ render () {
 
 ## Notes
 
-The onFingerUp method is triggered each time the user takes their finger off the pad. The 'signature' image data is then updated after a 1000ms delay. This allows for multiple strokes to be made without it creating a load of junk images. Note that when using an image format other than SVG, there will be temp image files building up on the device. Be sure to put a process in place to remove these once you have done whatever is it you need to do with the final image. You could push the responses into an array, take the last one and process it, then use RN file system to clear the lot.
+The onFingerUp method is triggered each time the user takes their finger off the pad. The 'signature' image data is then updated after a delay as defined by `onFingerUpTimeout` (default: 1000). This allows for multiple strokes to be made without it creating a load of junk images. Note that when using an image format other than SVG, there will be temp image files building up on the device. Be sure to put a process in place to remove these once you have done whatever is it you need to do with the final image. You could push the responses into an array, take the last one and process it, then use RN file system to clear the lot.
 
 You may want to set a slight offset to the touch-point using the x or y offset props. Through personal use, I have found that a yOffset of -60 is often reqired.
 
 ## Available props
 
-| Name            | Type             | Default   | Description                              |
-| --------------- | ---------------- | --------- | ---------------------------------------- |
-| height          | string or number | 300       | Height of the signature panel            |
-| width           | string or number | '100%'    | Width of the signature panel             |
-| offsetX         | number           | 0         | X offset of the finger touch point       |
-| offsetY         | number           | 0         | Y offset of the finger touch point       |
-| strokeColor     | string           | '#000'    | Stroke color                             |
-| strokeWidth     | number           | 3         | Stroke width                             |
-| imageOutputSize | number           | 480       | Size of image output (non SVG)           |
-| imageQuality    | number           | 1         | Image output quality, 0.1 to 1           |
-| imageFormat     | string           | 'png'     | Image output type ['png', 'jpg', 'svg]   |
-| outputType      | string           | 'tmpfile' | Output ['tmpFile', 'base64', 'data-uri'] |
-| onFingerUp      | function         | () => {}  | Callback with the image value            |
-| containerStyle  | object           | {}        | Style the signature container            |
+| Name              | Type             | Default   | Description                                          |
+| ----------------- | ---------------- | --------- | ---------------------------------------------------- |
+| height            | string or number | 300       | Height of the signature panel                        |
+| width             | string or number | '100%'    | Width of the signature panel                         |
+| offsetX           | number           | 0         | X offset of the finger touch point                   |
+| offsetY           | number           | 0         | Y offset of the finger touch point                   |
+| strokeColor       | string           | '#000'    | Stroke color                                         |
+| strokeWidth       | number           | 3         | Stroke width                                         |
+| imageOutputSize   | number           | 480       | Size of image output (non SVG)                       |
+| imageQuality      | number           | 1         | Image output quality, 0.1 to 1                       |
+| imageFormat       | string           | 'png'     | Image output type ['png', 'jpg', 'svg]               |
+| outputType        | string           | 'tmpfile' | Output ['tmpFile', 'base64', 'data-uri']             |
+| onFingerUp        | function         | () => {}  | Callback with the image value                        |
+| onFingerUpTimeout | number           | 1000      | Timeout in ms after which the signature is processed |
+| containerStyle    | object           | {}        | Style the signature container                        |
 
 ## That's it :)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ interface SignaturePanelProps {
 	strokeColor?: string;
 	strokeWidth?: number;
 	onFingerUp?: (...args: any[]) => any;
+	onFingerUpTimeout?: number;
 	onTouch?: (...args: any[]) => any;
 	onTouchEnd?: (...args: any[]) => any;
 	imageOutputSize?: number;
@@ -44,6 +45,7 @@ class SignaturePanel extends React.Component<SignaturePanelProps, SignaturePanel
 		offsetX: 0,
 		offsetY: 0,
 		onFingerUp: () => {},
+		onFingerUpTimeout: 1000,
 		onTouch: () => {},
 		onTouchEnd: () => {},
 		outputType: 'tmpfile',
@@ -97,7 +99,7 @@ class SignaturePanel extends React.Component<SignaturePanelProps, SignaturePanel
 			paths: [],
 			points: [],
 			posX: 0,
-			posY: 0
+			posY: 0,
 		});
 	}
 
@@ -207,7 +209,7 @@ class SignaturePanel extends React.Component<SignaturePanelProps, SignaturePanel
 	 */
 
 	private returnImageData({ paths, points }: { paths: any[]; points: any[] }) {
-		const { onFingerUp, imageFormat, outputType, imageOutputSize, imageQuality } = this.props;
+		const { onFingerUp, onFingerUpTimeout, imageFormat, outputType, imageOutputSize, imageQuality } = this.props;
 		return () => {
 			if (!['jpg', 'png', 'webm', 'raw'].includes(imageFormat)) {
 				onFingerUp(this.renderSvg(paths, points));
@@ -224,7 +226,7 @@ class SignaturePanel extends React.Component<SignaturePanelProps, SignaturePanel
 					});
 					onFingerUp(file);
 					SignaturePanel.timer = null;
-				}, 1000);
+				}, onFingerUpTimeout);
 			}
 		};
 	}


### PR DESCRIPTION
Hi,

This PR adds a customizable timeout for the `onFingerUp` function in case a developer wants to adjust this. 

In our use case we are saving the signature as base64 in the state, but we noticed some people were having issues with the signature not being picked up yet as soon as they hit the save button to submit it as JSON.